### PR TITLE
Update class-cookie-admin.php

### DIFF
--- a/cookie/class-cookie-admin.php
+++ b/cookie/class-cookie-admin.php
@@ -1413,8 +1413,7 @@ if (!class_exists("cmplz_cookie_admin")) {
 
         public function get_active_policy_id()
         {
-            $policy_id = get_option('complianz_active_policy_id');
-            $policy_id = $policy_id ? $policy_id : 1;
+            $policy_id = get_option('complianz_active_policy_id', 1);
             return $policy_id;
         }
 
@@ -1426,8 +1425,7 @@ if (!class_exists("cmplz_cookie_admin")) {
 
         public function upgrade_active_policy_id()
         {
-            $policy_id = get_option('complianz_active_policy_id');
-            $policy_id = $policy_id ? $policy_id : 1;
+            $policy_id = get_option('complianz_active_policy_id', 1);
             $policy_id++;
 
             update_option('complianz_active_policy_id', $policy_id);


### PR DESCRIPTION
@param mixed  $default Optional. Default value to return if the option does not exist. ( set to 1 )
get_option($option, $default)

If the option does not exist or does not have a value, then the return value
will be false (default). _Pass the default as 1_