### PR TITLE
#242 Fix theme template override bug creating $theme_file

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -33,11 +33,12 @@ if ( ! function_exists( 'cmplz_fields_filter' ) ) {
 
 if ( ! function_exists( 'cmplz_get_template' ) ) {
 
-	function cmplz_get_template( $file ) {
+	function cmplz_get_template( $filename ) {
 
-		$file       = trailingslashit( cmplz_path ) . 'templates/' . $file;
+		$file       = trailingslashit( cmplz_path ) . 'templates/' . $filename;
 		$theme_file = trailingslashit( get_stylesheet_directory() )
-		              . dirname( cmplz_path ) . $file;
+		              . trailingslashit( basename( cmplz_path ) )
+                      . 'templates/' . $filename;
 
 		if ( file_exists( $theme_file ) ) {
 			$file = $theme_file;


### PR DESCRIPTION
overwriting $file value makes building $theme_file difficult
replace dirname() with basename() to get plugin directory name from cmplz_path