### PR TITLE
Fix #247

### DIFF
--- a/assets/js/cookieconfig.js
+++ b/assets/js/cookieconfig.js
@@ -225,7 +225,8 @@ jQuery(document).ready(function ($) {
 			//check if there's an autoplay value we need to pass on
 			var autoplay = cmplzGetUrlParameter($(this).attr('src'), 'autoplay');
 			if (autoplay === '1') src = src + '&autoplay=1';
-			$(this).attr('src', src).load(function () {
+                        //console.log( src );
+			$(this).on( 'load' , function () {
 				//fitvids integration, a.o. Beaverbuilder
 				if (typeof $(this).parent().fitVids == 'function') {
 					$(this).parent().fitVids();
@@ -247,6 +248,7 @@ jQuery(document).ready(function ($) {
 					curElement.removeClass('cmplz-hidden');
 				});
 			});
+                        $(this).attr('src', src); // change source here to trigger "load" event
 		});
 
 		//other services, no iframe, with placeholders


### PR DESCRIPTION
Use jQuery `$('iframe').on('load',function())` method, THEN set `src` attribute.

May the previous method `$('iframe').load(function())` is ok, when the source is set after the listener, but the `on()` method is the recommended one.

This ensure compatibility with most versions of the jQuery.

Thanks