### PR TITLE
Fix text domain typos for WPML in config/config-i18n.php and settings…

### DIFF
--- a/config/config-i18n.php
+++ b/config/config-i18n.php
@@ -19,7 +19,7 @@ if ( false ) { // phpcs:ignore Generic.CodeAnalysis.UnconditionalIfStatement.Fou
 	__( 'It is necessary to carry out studies by a research body, ensuring, whenever possible, the anonymization of personal data', 'complianz-gdpr' );
 	__( 'It is necessary for the regular exercise of rights in judicial, administrative or arbitration proceedings', 'complianz-gdpr' );
 	__( 'It is necessary for the protection of health, exclusively, in a procedure performed by health professionals, health services or health authority', 'complianz-gdpr' );
-	__( 'It is necessary for credit protection', 'compianz-gdpr' );
+	__( 'It is necessary for credit protection', 'complianz-gdpr' );
 	__( 'Default', 'complianz-gdpr' );
 	__( 'English', 'complianz-gdpr' );
 	__( 'Danish', 'complianz-gdpr' );

--- a/settings/config/fields/general-settings/settings.php
+++ b/settings/config/fields/general-settings/settings.php
@@ -111,7 +111,7 @@ function cmplz_settings_fields($fields){
 			'type'     => 'checkbox',
 			'default'  => false,
 			'label'    => __( "Disable the monthly site scan, subsequent sync with cookiedatabase.org and compliance reporting.", "complianz-gdpr" ),
-			'tooltip'  => __('Stay up-to-date with our monthly newsletter, including the onboarding of certain features and information about plugin changes.', 'comlpianz-gdpr')
+			'tooltip'  => __('Stay up-to-date with our monthly newsletter, including the onboarding of certain features and information about plugin changes.', 'complianz-gdpr')
 		],
 		[
 			'id'       => 'enable_cookieblocker_ajax',


### PR DESCRIPTION
Corrected '_compianz-gdpr_' (`config/config-i18n.php` line 22) and '_comlpianz-gdpr_' (`settings/config/fields/general-settings/settings.php` line 114) to '**_complianz-gdpr_**'. Ensures all GDPR strings use the correct WPML domain.

Closes #449.