### PR TITLE
Add Live Preview Blueprint for WordPress.org

### DIFF
--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://playground.wordpress.net/blueprint-schema.json",
+  "landingPage": "/wp-admin/admin.php?page=complianz",
+  "preferredVersions": {
+    "php": "8.3",
+    "wp": "latest"
+  },
+  "features": {
+    "networking": false
+  },
+  "steps": [
+    {
+      "step": "login",
+      "username": "admin",
+      "password": "password"
+    },
+    {
+      "step": "installPlugin",
+      "pluginData": {
+        "resource": "wordpress.org/plugins",
+        "slug": "complianz-gdpr"
+      },
+      "options": {
+        "activate": true
+      }
+    },
+    {
+      "step": "setSiteOptions",
+      "options": {
+        "blogname": "Complianz GDPR Demo",
+
+        "cmplz_onboarding_dismissed": true,
+        "cmplz_wizard_completed_once": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Hi! I noticed that Complianz GDPR doesn't have a Live Preview button on its WordPress.org page yet, so I created a blueprint configuration for it.

## About Live Preview

The [Live Preview feature](https://developer.wordpress.org/plugins/wordpress-org/previews-and-blueprints/) allows users to try plugins directly in their browser without installing anything, powered by [WordPress Playground](https://playground.wordpress.net/). This can significantly increase user engagement and conversions.

**Learn more:**
- [Plugin Handbook - Previews and Blueprints](https://developer.wordpress.org/plugins/wordpress-org/previews-and-blueprints/)
- [WordPress Playground Documentation](https://wordpress.github.io/wordpress-playground/)

## What's Included

This PR adds `.wordpress-org/blueprints/blueprint.json` which configures the preview to:
- Install and activate Complianz GDPR
- Log users in automatically
- Direct them to the Complianz dashboard
- Skip the onboarding wizard for a faster demo experience

## Testing the Blueprint

You can test this blueprint right now in WordPress Playground (before merging):

<a href="https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2Fadamziel%2Fcomplianz-gdpr%2Fadd-wordpress-playground-blueprint%2F.wordpress-org%2Fblueprints%2Fblueprint.json"><img alt="Try it in Playground" width="300" src="https://raw.githubusercontent.com/WordPress/action-wp-playground-pr-preview/80f4a8b6d7ee3248abf09d373de965117a015ee0/assets/playground-preview-button.svg"></a>

This lets you see exactly how users will experience the Live Preview!

## How to Enable

After merging this PR, you'll need to manually deploy the blueprint to your WordPress.org SVN repository:

### Step 1: Deploy Blueprint to SVN

The `.wordpress-org` directory needs to be deployed to the SVN `assets` directory:

```bash
# Check out your plugin's SVN assets directory
svn co https://plugins.svn.wordpress.org/complianz-gdpr/assets svn-assets
cd svn-assets

# Create the blueprints directory if it doesn't exist
mkdir -p blueprints

# Copy the blueprint from your Git repository
cp /path/to/complianz-gdpr/.wordpress-org/blueprints/blueprint.json blueprints/

# Add and commit to SVN
svn add blueprints/blueprint.json
svn ci -m "Add WordPress Playground blueprint for Live Preview"
```

### Step 2: Enable Live Preview on WordPress.org

Once the blueprint is in SVN:

1. Log in to your WordPress.org account
2. Go to [your plugin's Advanced page](https://wordpress.org/plugins/complianz-gdpr/advanced/)
3. Scroll to **"Toggle Live Preview"**
4. Set the preview to **"public"**

The Live Preview button will then appear on your plugin page!

You can also test before enabling publicly by adding `?preview=1` to your plugin URL:
https://wordpress.org/plugins/complianz-gdpr/?preview=1

### Optional: Automate Future Deployments

To avoid manual SVN steps in the future, you could:
- Add the `.wordpress-org` directory to your existing deployment process
- Create a deployment script that syncs both the plugin and assets to SVN
- Use GitHub Actions with the [WordPress Plugin Deploy Action](https://github.com/10up/action-wordpress-plugin-deploy)

## Customization

Feel free to customize the blueprint to better showcase your plugin's features. You can:
- Change the landing page
- Add demo content or sample data
- Configure specific PHP/WordPress versions
- Add setup steps

See the [Blueprint documentation](https://wordpress.github.io/wordpress-playground/blueprints-api/index) for all available options.

---

Let me know if you'd like any adjustments to better showcase Complianz GDPR!