### PR TITLE
Remove unnecessary Content-Type headers from GET requests

### DIFF
--- a/cookiebanner/js/complianz.js
+++ b/cookiebanner/js/complianz.js
@@ -92,7 +92,6 @@ function cmplzLoadConsentAreaContent(consentedCategory, consentedService){
 			//if not stored yet, load. As features in the user object can be changed on updates, we also check for the version
 			let request = new XMLHttpRequest();
 			request.open('GET', complianz.url+'consent-area/'+postId+'/'+blockId, true);
-			request.setRequestHeader('Content-type', 'application/json');
 			request.send();
 			obj.classList.remove('cmplz-placeholder');
 			request.onload = function() {
@@ -1460,7 +1459,6 @@ if ( complianz.geoip == 1 && (cmplz_user_data.length == 0 || (cmplz_user_data.ve
 	let cmplzUserRegion = cmplz_get_url_parameter(window.location.href, 'cmplz_user_region');
 	cmplzUserRegion = cmplzUserRegion ? '&cmplz_user_region=' + cmplzUserRegion : '';
 	request.open('GET', complianz.url+'banner?'+complianz.locale+cmplzUserRegion, true);
-	request.setRequestHeader('Content-type', 'application/json');
 	request.send();
 	request.onload = function() {
 		cmplz_user_data = JSON.parse(request.response);
@@ -2072,7 +2070,6 @@ function cmplz_start_clean(){
 		if ( !cmplz_cookie_data || cmplz_cookie_data.length === 0 ) {
 			let request = new XMLHttpRequest();
 			request.open('GET', complianz.url+'cookie_data', true);
-			request.setRequestHeader('Content-type', 'application/json');
 			request.send();
 			request.onload = function() {
 				cmplz_cookie_data = JSON.parse(request.response);
@@ -2149,7 +2146,6 @@ function cmplz_load_manage_consent_container() {
 
 		let request = new XMLHttpRequest();
 		request.open('GET', complianz.url+'manage_consent_html?'+complianz.locale, true);
-		request.setRequestHeader('Content-type', 'application/json');
 		request.send();
 		request.onload = function() {
 			let html = JSON.parse(request.response);


### PR DESCRIPTION
The content type of GET requests should not be `application/json` because no body is being sent.

Although browsers will send out these requests, having `application/json` as the header is unexpected. This has the potential to cause incompatibilities with other plugins. For example [Altcha's](https://altcha.org/) WordPress plugin is incompatible with Complianz because of this (See altcha-org/altcha-wordpress-next#26).
