### PR TITLE
Add cmplz_generate_banner_css filter to allow skipping banner CSS generation

### DIFF
--- a/cookiebanner/class-cookiebanner.php
+++ b/cookiebanner/class-cookiebanner.php
@@ -1229,6 +1229,21 @@ if ( ! class_exists( 'cmplz_cookiebanner' ) ) {
 		 * @param bool $preview
 		 */
 		public function generate_css( $preview = false ): void {
+			/**
+			 * Filter whether the banner css file should be generated at all.
+			 * Return false to take over banner styling entirely, for example when
+			 * the banner is styled from a theme or a custom stylesheet.
+			 *
+			 * @since 7.5.4
+			 *
+			 * @param bool               $generate Whether to generate the file.
+			 * @param bool               $preview  True for the admin preview file.
+			 * @param CMPLZ_COOKIEBANNER $banner   The banner being generated.
+			 */
+			if ( ! apply_filters( 'cmplz_generate_banner_css', true, $preview, $this ) ) {
+				return;
+			}
+
 			if ( get_transient( 'cmplz_generate_css_active' ) ) {
 				return;
 			}


### PR DESCRIPTION
## Problem

There is currently no supported way to stop Complianz generating the banner CSS files in `uploads/complianz/css/`. Sites that style the cookie banner themselves — from a theme, a custom stylesheet, or inline — still get a file written per consent type on every banner save.

`generate_css()` is invoked as a direct method call, from `CMPLZ_COOKIEBANNER::save()` and from the `generate_preview_css` REST action, so there is no hook to unregister. The existing filters don't help either: `cmplz_banner_css_files` and `cmplz_cookiebanner_css` both run *after* `cmplz_upload_dir( 'css' )` has created the directory and before the `fopen()`/`fwrite()`, so emptying them yields a 0-byte file rather than no file.

The only externally reachable early return is the `cmplz_generate_css_active` re-entrancy guard, which can be forced truthy from `pre_transient_cmplz_generate_css_active`. That does work today, but it means depending on a re-entrancy lock as if it were an extension point: it breaks silently if the transient is ever renamed or the guard restructured, and semantically it claims a generation is in progress rather than expressing an opt-out.

## Change

One short-circuit at the top of `generate_css()`:

```php
if ( ! apply_filters( 'cmplz_generate_banner_css', true, $preview, $this ) ) {
	return;
}
```

Two details behind the placement:

- **Above the transient read**, so the method returns before `cmplz_upload_dir()` creates the directory and before any filesystem write. It also means the two mechanisms never interact — on a build with this filter, generation stops before the transient is consulted.
- **`$preview` is passed through**, so callers can disable front-end generation while letting the settings-screen preview keep generating `banner-preview-*.css`. Without it, opting out also leaves the admin live preview unstyled.

Usage:

```php
// disable everywhere
add_filter( 'cmplz_generate_banner_css', '__return_false' );

// disable on the front end, keep the admin preview working
add_filter( 'cmplz_generate_banner_css', function( $generate, $preview ) {
	return $preview;
}, 10, 2 );
```

## Notes

- Additive and backwards compatible: default `true` preserves current behaviour exactly, and no existing line is modified — the diff is 15 insertions, 0 deletions.
- No issue ID in the commit subject, as I didn't find an existing issue for this. Happy to open one and amend if you'd prefer it referenced.
- `@since 7.5.4` in the docblock is a guess at the next release; tell me what it should be and I'll correct it.
- Not covered by the test suite — `tests/` contains only `test-404.php`, `test-installer.php` and `test-share.php`, none of which touch banner CSS. I verified the two code paths (with and without the filter, and with the preview flag on and off) against a harness mirroring the real control flow; happy to add a PHPUnit case if you want one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
